### PR TITLE
ci: Pin actions to commit SHAs and update to latest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/docs"
+      - "/tests"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,10 @@ jobs:
             TOXENV: pypy3
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -45,7 +45,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: ${{ matrix.python-version == 3.13 && matrix.env.TOXENV == 'py' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
 
   checks:
     runs-on: ubuntu-latest
@@ -64,10 +64,10 @@ jobs:
             TOXENV: twinecheck
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,12 +13,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: 3.13
       - run: | 
           pip install --upgrade build
           python -m build
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2


### PR DESCRIPTION
## Context

Both workflows referenced actions by mutable refs — floating tags (`@v4`, `@v5`) and, for the PyPI publish step, a branch (`@release/v1`). A mutable ref runs whatever the upstream owner points it at today, so a compromised or force-pushed tag executes in our workflow. `publish.yml` holds `id-token: write` and publishes to PyPI via trusted publishing, which makes it the highest-value target in the repo.

Every action is now pinned to a full 40-char commit SHA with the version in a trailing comment, taking the latest majors along the way.

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | `@v4` | `3d3c42e` (v7.0.1) |
| `actions/setup-python` | `@v5` | `5fda3b9` (v7.0.0) |
| `codecov/codecov-action` | `@v4` | `fb8b358` (v7.0.0) |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `dc37677` (v1.14.2) |

`dc37677` is the current tip of `release/v1`, so that pin is behaviorally a no-op today — it just stops the branch from moving underneath the release job.

## Dependabot

Pinning without automation rots into "stuck on an old, vulnerable version", so this adds `.github/dependabot.yml`. Dependabot understands SHA-pinned actions and rewrites both the SHA and the `# vX.Y.Z` comment. Config covers `github-actions` plus `pip` across all three manifest locations (`pyproject.toml`, `docs/requirements.txt`, `tests/requirements.txt`).

## Compatibility

- checkout v6 / setup-python v6 / codecov v6 all moved to the Node 24 runtime, requiring runner >= v2.327.1. Both jobs use GitHub-hosted `ubuntu-latest`, well past that.
- checkout v7.0.0 blocks checking out fork PRs under `pull_request_target` / `workflow_run`. CI triggers on `[push, pull_request]` only, so this isn't hit.
- setup-python v7 dropped the `pip-install` input; it was never set here.
- The codecov step has no `with:` block, so none of the v5 input renames (`file` → `files`, etc.) apply. Tokenless upload for this public repo still works.
- The Python matrix (3.10–3.14, pypy3.11) is unaffected.

## Verification

Each SHA was resolved from the GitHub API and then re-resolved independently after editing; the annotated tags for codecov and gh-action-pypi-publish were dereferenced to their commits. All four matched. No mutable refs remain under `.github/`. All three YAML files parse.

CI on this PR exercises the six test legs and three check legs against the new pins. `publish.yml` only fires on a `X.Y.Z` tag push, so it isn't covered here — the next release is its first real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)